### PR TITLE
Merge experimental decimal format to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 go-currency
 fixedpoint/testdata/fuzz/FuzzX32PackUnpackRoundtrip
+coverage.out

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,1 @@
+go test ./fixedpoint/ -bench=. -benchmem -count=3

--- a/fixedpoint/conformance_test.go
+++ b/fixedpoint/conformance_test.go
@@ -68,7 +68,7 @@ func TestQuantizationRounding(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// For this test, we need to implement a quantize function
 			// that adjusts the exponent while preserving the value
-			result := quantize(tt.value, tt.expTarget, tt.mode)
+			result, _ := quantize64(tt.value, tt.expTarget, tt.mode)
 			got := result.String()
 			if got != tt.expected {
 				t.Errorf("quantize() = %q, want %q", got, tt.expected)

--- a/fixedpoint/context.go
+++ b/fixedpoint/context.go
@@ -140,7 +140,7 @@ func (ctx *Context64) Parse(s string) X64 {
 	coe := value
 
 	// Check for coefficient overflow.
-	if coe > MaxCoefficient64 || exp > Emax64 {
+	if coe > maxCoefficient64 || exp > eMax64 {
 		ctx.signals |= SignalOverflow
 		return newSpecial64(signc_positive, kind_signaling)
 	}
@@ -223,7 +223,7 @@ func (ctx *Context32) Parse(s string) X32 {
 	coe := uint32(value)
 
 	// Check for coefficient overflow.
-	if coe > MaxCoefficient32 || exp > Emax32 {
+	if coe > maxCoefficient32 || exp > eMax32 {
 		ctx.signals |= SignalOverflow
 		return newSpecial32(signc_positive, kind_signaling)
 	}
@@ -259,7 +259,7 @@ func (ctx *Context64) Clone(clear bool) *Context64 {
 	}
 }
 
-func (ctx *Context32) CLone(clear bool) *Context32 {
+func (ctx *Context32) Clone(clear bool) *Context32 {
 	if ctx == nil {
 		return nil
 	}

--- a/fixedpoint/context.go
+++ b/fixedpoint/context.go
@@ -2,8 +2,24 @@ package fixedpoint
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
+)
+
+type Context[X X64 | X32] interface {
+	Parse(s string) X
+	HandleSignals(original, fallback X) X
+	ClearSignals()
+	Signal() Signal
+	Traps() Signal
+	Precision() Precision
+	Rounding() Rounding
+}
+
+var (
+	_ Context[X64] = (*Context64)(nil)
+	_ Context[X32] = (*Context32)(nil)
 )
 
 // Context64 represents the context for computing 64-bit decimal floating-point numbers.
@@ -16,11 +32,23 @@ type Context32 struct {
 	context
 }
 
+// context holds the width-independent elements of the context.
 type context struct {
 	traps     Signal    // The current signal traps.
 	signals   Signal    // The current signal state.
 	precision Precision // The precision (number of significant digits).
 	rounding  Rounding  // The rounding mode.
+	locale    Locale    // The locale settings.
+}
+
+type Locale struct {
+	decimals  string // The decimal separators.
+	thousands string // The thousands separators.
+}
+
+var DefaultLocale = Locale{
+	decimals:  ".",
+	thousands: ",_",
 }
 
 // Default Basic Context Values.
@@ -32,206 +60,108 @@ const (
 // Default Extended Context values.
 const ()
 
-var ErrUnsupportedPrecision = fmt.Errorf("unsupported precision")
+var (
+	ErrUnsupportedPrecision = fmt.Errorf("unsupported precision")
+	ErrUnknownRounding      = fmt.Errorf("unknown rounding mode")
+)
 
-// NewContext creates a new context with the specified precision, rounding mode, and enabled traps.
-func NewContext[C Context64 | Context32](precision Precision, rounding Rounding, traps Signal) (*C, error) {
-	if precision < PrecisionMinimum || precision > PrecisionMaximum64 {
-		return nil, ErrUnsupportedPrecision
+func NewContext64(precision Precision, rounding Rounding, traps Signal, locale Locale) (*Context64, error) {
+	context, err := newContext(precision, rounding, traps, locale, PrecisionMaximum64)
+	if err != nil {
+		return nil, err
 	}
 
-	return &C{
-		context: context{
-			precision: precision,
-			rounding:  rounding,
-			traps:     traps,
-			signals:   Signal(0),
-		},
+	return &Context64{
+		context: context,
+	}, nil
+}
+
+func NewContext32(precision Precision, rounding Rounding, traps Signal, locale Locale) (*Context32, error) {
+	context, err := newContext(precision, rounding, traps, locale, PrecisionMaximum32)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Context32{
+		context: context,
 	}, nil
 }
 
 // BasicContext32 returns a basic context with default values.
 func BasicContext32() *Context32 {
-	return &Context32{
-		context: context{
-			precision: PrecisionDefault32,
-			rounding:  BasicRounding,
-			traps:     BasicTraps,
-			signals:   Signal(0),
-		},
+	c, err := NewContext32(PrecisionDefault32, BasicRounding, BasicTraps, DefaultLocale)
+	if err != nil {
+		panic(err)
 	}
+
+	return c
 }
 
 // BasicContext64 returns a basic context with default values.
 func BasicContext64() *Context64 {
-	return &Context64{
-		context: context{
-			precision: PrecisionDefault64,
-			rounding:  BasicRounding,
-			traps:     BasicTraps,
-			signals:   Signal(0),
-		},
+	c, err := NewContext64(PrecisionDefault64, BasicRounding, BasicTraps, DefaultLocale)
+	if err != nil {
+		panic(err)
 	}
+
+	return c
 }
 
 // Parse converts a string into a FixedPoint value.
 // It handles special values (e.g., "NaN", "Infinity") and parses finite numbers.
 func (ctx *Context64) Parse(s string) X64 {
-	// Trim surrounding spaces.
-	s = strings.TrimSpace(s)
-	if s == "" {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial64(signc_positive, kind_signaling)
+	if ctx == nil {
+		ctx = BasicContext64()
 	}
 
-	// Handle special values (case-insensitive).
-	lower := strings.ToLower(s)
-	switch lower {
-	case "nan", "+nan":
-		return newSpecial64(signc_positive, kind_quiet)
-	case "-nan":
-		return newSpecial64(signc_negative, kind_quiet)
-	case "inf", "infinity", "+inf", "+infinity":
-		return newSpecial64(signc_positive, kind_infinity)
-	case "-inf", "-infinity":
-		return newSpecial64(signc_negative, kind_infinity)
-	}
-
-	// Determine s_sign.
-	s_sign := signc_positive
-	switch s[0] {
-	case '-':
-		s_sign = signc_negative
-		s = s[1:]
-	case '+':
-		s = s[1:]
-	}
-
-	// Split the input on the decimal point.
-	parts := strings.Split(s, ".")
-	if len(parts) > 2 {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial64(signc_positive, kind_signaling)
-	}
-
-	intPart := parts[0]
-	fracPart := ""
-	if len(parts) == 2 {
-		fracPart = parts[1]
-	}
-	if intPart == "" && fracPart == "" {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial64(signc_positive, kind_signaling)
-	}
-
-	// Concatenate the integer and fractional digits.
-	digits := intPart + fracPart
-
-	// Attempt to parse the digits into a uint64.
-	value, err := strconv.ParseUint(digits, 10, 64)
-	if err != nil {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial64(signc_positive, kind_signaling)
-	}
-
-	// Determine the exponent.
-	// For example, "123.45" becomes 12345 with an exponent of -2.
-	exp := int16(-len(fracPart))
-	coe := value
-
-	// Check for coefficient overflow.
-	if coe > maxCoefficient64 || exp > eMax64 {
-		ctx.signals |= SignalOverflow
-		return newSpecial64(signc_positive, kind_signaling)
+	sign, kind, coe, exp, signals := parseInput(&ctx.context, s, maxCoefficient64, eMax64)
+	ctx.signals |= signals
+	if kind != kind_finite {
+		return newSpecial64(sign, kind)
 	}
 
 	var a X64
-	err = a.pack(kind_finite, s_sign, exp, coe)
+	err := a.pack(kind_finite, sign, exp, uint64(coe))
 	if err != nil {
 		ctx.signals |= SignalConversionSyntax
+		return newSpecial64(signc_positive, kind_signaling)
+	}
+
+	err = a.Round(ctx.rounding, ctx.precision)
+	if err != nil {
+		log.Printf("Rounding error: %v", err)
+		ctx.signals |= SignalInvalidOperation
 		return newSpecial64(signc_positive, kind_signaling)
 	}
 
 	return a
-
-	// return apply_precision(
-	// 	new(FiniteNumber).Init(sign, coe, exp),
-	// 	ctx)
 }
 
 func (ctx *Context32) Parse(s string) X32 {
-	// Trim surrounding spaces.
-	s = strings.TrimSpace(s)
-	if s == "" {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial32(signc_positive, kind_signaling)
+	if ctx == nil {
+		ctx = BasicContext32()
 	}
 
-	// Handle special values (case-insensitive).
-	lower := strings.ToLower(s)
-	switch lower {
-	case "nan", "+nan":
-		return newSpecial32(signc_positive, kind_quiet)
-	case "-nan":
-		return newSpecial32(signc_negative, kind_quiet)
-	case "inf", "infinity", "+inf", "+infinity":
-		return newSpecial32(signc_positive, kind_infinity)
-	case "-inf", "-infinity":
-		return newSpecial32(signc_negative, kind_infinity)
+	sign, kind, coe, exp, signals := parseInput(&ctx.context, s, maxCoefficient32, eMax32)
+	ctx.signals |= signals
+	if kind != kind_finite {
+		return newSpecial32(sign, kind)
 	}
 
-	// Determine s_sign.
-	s_sign := signc_positive
-	switch s[0] {
-	case '-':
-		s_sign = signc_negative
-		s = s[1:]
-	case '+':
-		s = s[1:]
-	}
-
-	// Split the input on the decimal point.
-	parts := strings.Split(s, ".")
-	if len(parts) > 2 {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial32(signc_positive, kind_signaling)
-	}
-
-	intPart := parts[0]
-	fracPart := ""
-	if len(parts) == 2 {
-		fracPart = parts[1]
-	}
-	if intPart == "" && fracPart == "" {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial32(signc_positive, kind_signaling)
-	}
-
-	// Concatenate the integer and fractional digits.
-	digits := intPart + fracPart
-
-	// Attempt to parse the digits into a uint32.
-	value, err := strconv.ParseUint(digits, 10, 32)
-	if err != nil {
-		ctx.signals |= SignalConversionSyntax
-		return newSpecial32(signc_positive, kind_signaling)
-	}
-
-	// Determine the exponent.
-	// For example, "123.45" becomes 12345 with an exponent of -2.
-	exp := int8(-len(fracPart))
-	coe := uint32(value)
-
-	// Check for coefficient overflow.
-	if coe > maxCoefficient32 || exp > eMax32 {
-		ctx.signals |= SignalOverflow
-		return newSpecial32(signc_positive, kind_signaling)
-	}
-
+	// Pack the parsed values into an X32 object.
 	var a X32
-	err = a.pack(kind_finite, s_sign, exp, coe)
+	err := a.pack(kind_finite, sign, exp, uint32(coe))
 	if err != nil {
 		ctx.signals |= SignalConversionSyntax
+		return newSpecial32(signc_positive, kind_signaling)
+	}
+
+	// Apply rounding to the result.
+	err = a.Round(ctx.rounding, ctx.precision)
+	if err != nil {
+		// TODO: Add signal for rounding error
+		log.Printf("Rounding error: %v", err)
+		ctx.signals |= SignalInvalidOperation
 		return newSpecial32(signc_positive, kind_signaling)
 	}
 
@@ -279,16 +209,285 @@ func (ctx *Context32) Clone(clear bool) *Context32 {
 	}
 }
 
+// HandleSignals checks the current signal state and returns the appropriate value.
+func (ctx *Context64) HandleSignals(original, fallback X64) X64 {
+	if ctx == nil {
+		panic("Context64 is nil")
+	}
+
+	if ctx.signals&ctx.traps != 0 {
+		return fallback
+	}
+
+	return original
+}
+
+// HandleSignals checks the current signal state and returns the appropriate value.
+func (ctx *Context32) HandleSignals(original, fallback X32) X32 {
+	if ctx == nil {
+		panic("Context32 is nil")
+	}
+
+	if ctx.signals&ctx.traps != 0 {
+		return fallback
+	}
+
+	return original
+}
+
+func (ctx *Context64) Add(a, b X64) X64 {
+	if ctx == nil {
+		panic("Context64 is nil")
+	}
+
+	akind, asign, aexp, acoe, err := a.unpack()
+	if err != nil {
+		ctx.signals |= SignalInvalidOperation
+		return newSpecial64(signc_positive, kind_signaling)
+	}
+
+	if akind == kind_signaling || akind == kind_quiet {
+		return a
+	}
+
+	bkind, bsign, bexp, bcoe, err := b.unpack()
+	if err != nil {
+		ctx.signals |= SignalInvalidOperation
+		return newSpecial64(signc_positive, kind_signaling)
+	}
+
+	if bkind == kind_signaling || bkind == kind_quiet {
+		return b
+	}
+
+	// Handle infinity
+	if akind == kind_infinity || bkind == kind_infinity {
+		if asign == bsign {
+			return newSpecial64(asign, kind_infinity)
+		}
+		return newSpecial64(signc_positive, kind_signaling)
+	}
+
+	// adjust the coefficients so exp is the same
+	if aexp > bexp {
+		bexp += aexp - bexp
+		bcoe >>= aexp - bexp
+	}
+	if bexp > aexp {
+		aexp += bexp - aexp
+		acoe >>= bexp - aexp
+	}
+
+	// add or subtract the coefficients according to the signs
+	if asign == bsign {
+		acoe += bcoe
+	} else {
+		if acoe > bcoe {
+			acoe -= bcoe
+		} else {
+			acoe = bcoe - acoe
+			asign = signc_negative
+		}
+	}
+
+	var c X64
+	err = c.pack(kind_finite, asign, aexp, acoe)
+	if err != nil {
+		ctx.signals |= SignalInvalidOperation
+		return newSpecial64(signc_positive, kind_signaling)
+	}
+
+	err = c.Round(ctx.rounding, ctx.precision)
+	if err != nil {
+		ctx.signals |= SignalInvalidOperation
+		return newSpecial64(signc_positive, kind_signaling)
+	}
+
+	return c
+}
+
+func (ctx *Context64) String() string {
+	if ctx == nil {
+		return "nil"
+	}
+
+	return fmt.Sprintf("Context64{precision: %d, rounding: %d, traps: %d, signals: %d}",
+		ctx.precision, ctx.rounding, ctx.traps, ctx.signals)
+}
+
+func (ctx *Context32) String() string {
+	if ctx == nil {
+		return "nil"
+	}
+
+	return fmt.Sprintf("Context32{precision: %d, rounding: %d, traps: %d, signals: %d}",
+		ctx.precision, ctx.rounding, ctx.traps, ctx.signals)
+}
+
 // ClearSignals clears the current signal state of the context.
-func (ctx *Context64) ClearSignals() {
-	ctx.signals = Signal(0)
+func (ctx *context) ClearSignals() {
+	if ctx != nil {
+		ctx.signals = Signal(0)
+	}
 }
 
 // Signal retrieves the current signal state of the context.
-func (ctx *Context64) Signal() Signal {
+func (ctx *context) Signal() Signal {
 	if ctx == nil {
 		return SignalInvalidOperation
 	}
 
 	return ctx.signals
+}
+
+// Traps retrieves the current signal traps of the context.
+func (ctx *context) Traps() Signal {
+	if ctx == nil {
+		return SignalInvalidOperation
+	}
+
+	return ctx.traps
+}
+
+// Precision retrieves the current precision of the context.
+func (ctx *context) Precision() Precision {
+	if ctx == nil {
+		return Precision(0)
+	}
+
+	return ctx.precision
+}
+
+// Rounding retrieves the current rounding mode of the context.
+func (ctx *context) Rounding() Rounding {
+	if ctx == nil {
+		return Rounding(0)
+	}
+
+	return ctx.rounding
+}
+
+func newContext(p Precision, r Rounding, traps Signal, l Locale, maxP Precision) (context, error) {
+	if p < PrecisionMinimum || p > maxP {
+		return context{}, ErrUnsupportedPrecision
+	}
+	if r < DefaultRoundingMode || r > MaxRoundingMode {
+		return context{}, ErrUnknownRounding
+	}
+
+	return context{
+		precision: p,
+		rounding:  r,
+		traps:     traps,
+		signals:   Signal(0),
+		locale:    l,
+	}, nil
+}
+
+func parseInput[C uint64 | uint32, E int8 | int16](
+	ctx *context,
+	s string,
+	maxCoefficient C,
+	eMax E,
+) (signc, kind, C, E, Signal) {
+	if ctx == nil {
+		return signc_positive, kind_signaling, 0, 0, SignalInvalidOperation
+	}
+
+	s = normalizeInput(s, ctx.locale)
+	if s == "" {
+		return signc_positive, kind_signaling, 0, 0, SignalConversionSyntax
+	}
+
+	sign, kind, isSpecial := isSpecial(s)
+	if isSpecial {
+		return sign, kind, 0, 0, Signal(0)
+	}
+
+	sign, digits, exp, ok := getDigitString[E](s)
+	if !ok {
+		return signc_positive, kind_signaling, 0, 0, SignalConversionSyntax
+	}
+
+	value, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return signc_positive, kind_signaling, 0, 0, SignalConversionSyntax
+	}
+
+	if value > uint64(maxCoefficient) || exp > eMax {
+		return signc_positive, kind_signaling, 0, 0, SignalOverflow
+	}
+
+	return sign, kind, C(value), E(exp), Signal(0)
+}
+
+func normalizeInput(input string, locale Locale) string {
+	// Trim surrounding spaces.
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+
+	input = strings.ToLower(input)
+	input = strings.ReplaceAll(input, " ", "")
+
+	for _, sep := range locale.decimals {
+		if sep != '.' {
+			input = strings.ReplaceAll(input, string(sep), ".")
+		}
+	}
+
+	for _, sep := range locale.thousands {
+		input = strings.ReplaceAll(input, string(sep), "")
+	}
+
+	return input
+}
+
+func isSpecial(s string) (signc, kind, bool) {
+	switch s {
+	case "nan", "+nan":
+		return signc_positive, kind_quiet, true
+	case "-nan":
+		return signc_negative, kind_quiet, true
+	case "inf", "infinity", "+inf", "+infinity":
+		return signc_positive, kind_infinity, true
+	case "-inf", "-infinity":
+		return signc_negative, kind_infinity, true
+	default:
+		return signc_error, kind_finite, false
+	}
+}
+
+func getDigitString[E int8 | int16](s string) (signc, string, E, bool) {
+	if s == "" {
+		return signc_positive, "", 0, false
+	}
+	// Determine s_sign.
+	s_sign := signc_positive
+	switch s[0] {
+	case '-':
+		s_sign = signc_negative
+		s = s[1:]
+	case '+':
+		s = s[1:]
+	}
+
+	parts := strings.Split(s, ".")
+	if len(parts) > 2 {
+		return signc_positive, "", 0, false
+	}
+
+	intPart := parts[0]
+	fracPart := ""
+	if len(parts) == 2 {
+		fracPart = parts[1]
+	}
+	if intPart == "" && fracPart == "" {
+		return signc_positive, "", 0, false
+	}
+
+	// Determine the exponent.
+	// For example, "123.45" becomes 12345 with an exponent of -2.
+	return s_sign, intPart + fracPart, E(-len(fracPart)), true
 }

--- a/fixedpoint/fixedpoint.go
+++ b/fixedpoint/fixedpoint.go
@@ -2,6 +2,11 @@
 // using the Binary Integer Decimal (BID) encoding.
 package fixedpoint
 
+import (
+	"log"
+	"unsafe"
+)
+
 // Sign represents the sign of a decimal floating-point number
 type signc int8
 
@@ -70,4 +75,163 @@ func newSpecial32(sign signc, kind kind) X32 {
 		panic(newInternalError(res, "invalid kind"))
 	}
 	return res
+}
+
+// quantize64 adjusts the decimal64 value to the target exponent using the specified rounding mode.
+// quantize64 implements the IEEE 754-2008 quantize operation.
+func quantize64(x X64, expTarget int16, mode Rounding) (X64, Signal) {
+	k, sign, exp, coe, err := x.unpack()
+	if err != nil || k != kind_finite {
+		return x, SignalInvalidOperation // Return the original for special values
+	}
+
+	// Calculate the shift amount
+	shift := expTarget - exp
+	if shift == 0 {
+		return x, Signal(0)
+	}
+
+	var result X64
+	if shift < 0 {
+		// Reduce precision (move decimal point right)
+		multiplier := pow10[uint64](uint(-shift))
+		if coe > maxCoefficient64/multiplier {
+			// Overdlow
+			return X64{}, SignalOverflow
+		}
+		coe *= multiplier
+	} else {
+		// Increase precision (move decimal point left)
+		divisor := pow10[uint64](uint(shift))
+		quotient, remainder := coe/divisor, coe%divisor
+		halfDivisor := divisor / 2
+
+		switch mode {
+		case RoundTiesToEven:
+			if remainder > halfDivisor || (remainder == halfDivisor && (quotient&1) == 1) {
+				quotient++
+			}
+		case RoundTiesToAway:
+			if remainder >= halfDivisor {
+				quotient++
+			}
+		case RoundTowardPositive:
+			if remainder > 0 && sign == signc_positive {
+				quotient++
+			}
+		case RoundTowardNegative:
+			if remainder > 0 && sign == signc_negative {
+				quotient++
+			}
+		}
+		coe = quotient
+	}
+
+	err = result.pack(k, sign, expTarget, coe)
+	if err != nil {
+		log.Println("Error packing result:", err)
+		return X64{}, SignalInvalidOperation
+	}
+
+	return result, Signal(0)
+}
+
+// quantize32 adjusts the decimal32 value to the target exponent using the specified rounding mode.
+// quantize32 implements the IEEE 754-2008 quantize operation.
+func quantize32(x X32, expTarget int8, mode Rounding) (X32, Signal) {
+	k, sign, exp, coe, err := x.unpack()
+	if err != nil || k != kind_finite {
+		return x, SignalInvalidOperation // Return the original for special values
+	}
+
+	// Calculate the shift amount
+	shift := expTarget - exp
+	if shift == 0 {
+		return x, Signal(0)
+	}
+
+	var result X32
+	if shift < 0 {
+		// Reduce precision (move decimal point right)
+		multiplier := pow10[uint32](uint(-shift))
+		if coe > maxCoefficient32/multiplier {
+			// Overflow
+			return X32{}, SignalOverflow
+		}
+		coe *= multiplier
+	} else {
+		// Increase precision (move decimal point left)
+		divisor := pow10[uint32](uint(shift))
+		quotient, remainder := coe/divisor, coe%divisor
+		halfDivisor := divisor / 2
+
+		switch mode {
+		case RoundTiesToEven:
+			if remainder > halfDivisor || (remainder == halfDivisor && (quotient&1) == 1) {
+				quotient++
+			}
+		case RoundTiesToAway:
+			if remainder >= halfDivisor {
+				quotient++
+			}
+		case RoundTowardPositive:
+			if remainder > 0 && sign == signc_positive {
+				quotient++
+			}
+		case RoundTowardNegative:
+			if remainder > 0 && sign == signc_negative {
+				quotient++
+			}
+		}
+		coe = quotient
+	}
+
+	err = result.pack(k, sign, expTarget, coe)
+	if err != nil {
+		return X32{}, SignalInvalidOperation
+	}
+
+	return result, Signal(0)
+}
+
+var pow10Lookup = []uint64{
+	1,
+	10,
+	100,
+	1000,
+	10000,
+	100000,
+	1000000,
+	10000000,
+	100000000,
+	1000000000,
+	10000000000,
+	100000000000,
+	1000000000000,
+	10000000000000,
+	100000000000000,
+	1000000000000000,
+	10000000000000000,
+	100000000000000000,
+	1000000000000000000,
+	10000000000000000000,
+}
+
+// pow10 computes 10^n
+func pow10[U uint32 | uint64](n uint) (res U) {
+	const maxIndex4 = 9
+	const maxIndex8 = 19
+
+	switch unsafe.Sizeof(res) {
+	case 4:
+		if uintptr(n) <= maxIndex4 {
+			return U(pow10Lookup[n])
+		}
+	case 8:
+		if uintptr(n) <= maxIndex8 {
+			return U(pow10Lookup[n])
+		}
+	}
+
+	return 0
 }

--- a/fixedpoint/fixedpoint_benchmark_test.go
+++ b/fixedpoint/fixedpoint_benchmark_test.go
@@ -54,3 +54,11 @@ func BenchmarkString(b *testing.B) {
 		_ = x.String()
 	}
 }
+
+func BenchmarkParse(b *testing.B) {
+	c := BasicContext64()
+
+	for b.Loop() {
+		_ = c.Parse("-1234567.890")
+	}
+}

--- a/fixedpoint/fixedpoint_benchmark_test.go
+++ b/fixedpoint/fixedpoint_benchmark_test.go
@@ -29,3 +29,28 @@ func BenchmarkUnpack(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkQuantize(b *testing.B) {
+	var x X64
+	if err := x.pack(kind_finite, signc_positive, 0, 123456789012345); err != nil {
+		b.Fatalf("pack failed: %v", err)
+	}
+
+	for b.Loop() {
+		_, err := quantize64(x, 0, RoundTiesToEven)
+		if err != Signal(0) {
+			b.Fatalf("quantize failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkString(b *testing.B) {
+	var x X64
+	if err := x.pack(kind_finite, signc_positive, 0, 0); err != nil {
+		b.Fatalf("pack failed: %v", err)
+	}
+
+	for b.Loop() {
+		_ = x.String()
+	}
+}

--- a/fixedpoint/rounding.go
+++ b/fixedpoint/rounding.go
@@ -32,7 +32,10 @@ const (
 )
 
 // DefaultRoundingMode is the default rounding mode (RoundTiesToEven)
-const DefaultRoundingMode = RoundTiesToEven
+const (
+	DefaultRoundingMode = RoundTiesToEven
+	MaxRoundingMode     = RoundTowardZero
+)
 
 // String returns the string representation of the rounding mode.
 func (r Rounding) String() string {
@@ -70,15 +73,16 @@ func (r Rounding) Debug() string {
 	}
 }
 
-// Apply applies the specified rounding mode to a coefficient to reduce it to the target precision.
+// apply applies the specified rounding mode to a coefficient to reduce it to the target precision.
 // It returns the rounded coefficient and the number of digits removed.
-func Apply[E int8 | int16, C uint32 | uint64](mode Rounding, coef C, exp E, precision uint, sign signc) (C, uint) {
+func apply[E int8 | int16, C uint32 | uint64](mode Rounding, coef C, exp E, prec Precision, sign signc) (C, uint8) {
 	if coef == 0 {
 		return 0, 0 // Zero doesn't need rounding
 	}
 
 	digits := countDigits(coef)
 
+	precision := uint8(prec)
 	// If we're already at or below the target precision, no rounding needed
 	if digits <= precision {
 		return coef, 0
@@ -93,7 +97,7 @@ func Apply[E int8 | int16, C uint32 | uint64](mode Rounding, coef C, exp E, prec
 
 	// Calculate divisor (10^digitsToRemove)
 	var divisor, powerOfTen C = 1, 10
-	for i := uint(1); i <= digitsToRemove; i++ {
+	for i := uint8(1); i <= digitsToRemove; i++ {
 		divisor *= powerOfTen
 	}
 
@@ -140,12 +144,12 @@ func Apply[E int8 | int16, C uint32 | uint64](mode Rounding, coef C, exp E, prec
 }
 
 // countDigits returns the number of decimal digits in a number.
-func countDigits[T uint32 | uint64](n T) uint {
+func countDigits[T uint32 | uint64](n T) uint8 {
 	if n == 0 {
 		return 1
 	}
 
-	var count uint = 0
+	var count uint8 = 0
 	for n > 0 {
 		n /= 10
 		count++

--- a/fixedpoint/rounding_test.go
+++ b/fixedpoint/rounding_test.go
@@ -40,7 +40,7 @@ func TestRoundingApply64(t *testing.T) {
 		precision uint
 		sign      signc
 		expected  uint64
-		removed   uint
+		removed   uint8
 	}{
 		// RoundTiesToEven (banker's rounding)
 		{"TiesToEven-NoRounding", RoundTiesToEven, 123, 0, 3, signc_positive, 123, 0},
@@ -84,7 +84,7 @@ func TestRoundingApply64(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rounded, removed := Apply(test.rounding, test.coe, test.exp, test.precision, test.sign)
+			rounded, removed := apply(test.rounding, test.coe, test.exp, Precision(test.precision), test.sign)
 			if rounded != test.expected {
 				t.Errorf("Apply() rounded = %v, want %v", rounded, test.expected)
 			}
@@ -105,7 +105,7 @@ func TestRoundingApply32(t *testing.T) {
 		precision uint
 		sign      signc
 		expected  uint32
-		removed   uint
+		removed   uint8
 	}{
 		// RoundTiesToEven (banker's rounding)
 		{"TiesToEven-NoRounding", RoundTiesToEven, 123, 0, 3, signc_positive, 123, 0},
@@ -120,7 +120,7 @@ func TestRoundingApply32(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rounded, removed := Apply(test.rounding, test.coe, test.exp, test.precision, test.sign)
+			rounded, removed := apply(test.rounding, test.coe, test.exp, Precision(test.precision), test.sign)
 			if rounded != test.expected {
 				t.Errorf("Apply() rounded = %v, want %v", rounded, test.expected)
 			}
@@ -135,7 +135,7 @@ func TestRoundingApply32(t *testing.T) {
 func TestCountDigits(t *testing.T) {
 	tests := []struct {
 		value    uint64
-		expected uint
+		expected uint8
 	}{
 		{0, 1},
 		{1, 1},

--- a/fixedpoint/x32.go
+++ b/fixedpoint/x32.go
@@ -196,7 +196,7 @@ func (x *X32) isInf() bool {
 
 // Round applies the specified rounding mode to an X32 value to achieve the target precision.
 // It implements the rounding behavior defined in IEEE 754-2008.
-func (x *X32) Round(mode Rounding, precision uint) error {
+func (x *X32) Round(mode Rounding, precision Precision) error {
 	k, sign, exp, coe, err := x.unpack()
 	if err != nil {
 		return err
@@ -211,12 +211,12 @@ func (x *X32) Round(mode Rounding, precision uint) error {
 	digits := countDigits(coe)
 
 	// If we're already at or below the target precision, no rounding needed
-	if digits <= precision {
+	if digits <= uint8(precision) {
 		return nil
 	}
 
 	// Apply rounding to the coefficient
-	newCoe, digitsRemoved := Apply(mode, coe, exp, precision, sign)
+	newCoe, digitsRemoved := apply(mode, coe, exp, precision, sign)
 
 	// If digits were removed, adjust the exponent
 	if digitsRemoved > 0 {

--- a/fixedpoint/x64.go
+++ b/fixedpoint/x64.go
@@ -206,7 +206,7 @@ func (x *X64) isInf() bool {
 
 // Round applies the specified rounding mode to an X64 value to achieve the target precision.
 // It implements the rounding behavior defined in IEEE 754-2008.
-func (x *X64) Round(mode Rounding, precision uint) error {
+func (x *X64) Round(mode Rounding, prec Precision) error {
 	k, sign, exp, coe, err := x.unpack()
 	if err != nil {
 		return err
@@ -221,12 +221,12 @@ func (x *X64) Round(mode Rounding, precision uint) error {
 	digits := countDigits(coe)
 
 	// If we're already at or below the target precision, no rounding needed
-	if digits <= precision {
+	if digits <= uint8(prec) {
 		return nil
 	}
 
 	// Apply rounding to the coefficient
-	newCoe, digitsRemoved := Apply(mode, coe, exp, precision, sign)
+	newCoe, digitsRemoved := apply(mode, coe, exp, prec, sign)
 
 	// If digits were removed, adjust the exponent
 	if digitsRemoved > 0 {

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.10.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -7,34 +7,51 @@ import (
 )
 
 func main() {
-	cx := fp.BasicContext64()
+	cx, _ := fp.NewContext64(
+		fp.PrecisionMaximum64-4,
+		fp.RoundTiesToEven,
+		fp.BasicTraps,
+		fp.DefaultLocale)
 
-	q := cx.Parse("-1234567.45")
+	cy, _ := fp.NewContext64(
+		fp.PrecisionMaximum64-6,
+		fp.RoundTiesToEven,
+		fp.BasicTraps,
+		fp.DefaultLocale)
+
+	q := cy.Parse("-1_234_567.45")
 	fmt.Printf("%s\t%s\n", q.String(), q.Debug())
 	fmt.Printf("Packed: %#064b\n", q)
 	fmt.Printf("Packed: %#016X\n", q)
 	fmt.Printf("Packed: %020d\n", q)
 	println("--------------------")
 
-	w := cx.Parse("-1.457845784578")
+	w := cy.Parse("-1.457845784578")
 	fmt.Printf("%s\t%s\n", w.String(), w.Debug())
 	fmt.Printf("Packed: %#064b\n", w)
 	fmt.Printf("Packed: %#016X\n", w)
 	fmt.Printf("Packed: %020d\n", w)
 	println("--------------------")
 
-	e := cx.Parse("-Infinity")
+	e := cy.Parse("-Infinity")
 	fmt.Printf("%s\t%s\n", e.String(), e.Debug())
 	fmt.Printf("Packed: %#064b\n", e)
 	fmt.Printf("Packed: %#016X\n", e)
 	fmt.Printf("Packed: %020d\n", e)
 	println("--------------------")
 
-	r := cx.Parse("NaN")
+	r := cy.Parse("NaN")
 	fmt.Printf("%s\t%s\n", r.String(), r.Debug())
 	fmt.Printf("Packed: %#064b\n", r)
 	fmt.Printf("Packed: %#016X\n", r)
 	fmt.Printf("Packed: %020d\n", r)
+	println("--------------------")
+
+	t := cx.Parse("9_876_543.6555")
+	fmt.Printf("%s\t%s\n", t.String(), t.Debug())
+	fmt.Printf("Packed: %#064b\n", t)
+	fmt.Printf("Packed: %#016X\n", t)
+	fmt.Printf("Packed: %020d\n", t)
 	println("--------------------")
 
 	var a fp.X64
@@ -67,4 +84,13 @@ func main() {
 	fmt.Printf("Packed: %#016X\n", a)
 	fmt.Printf("Packed: %020d\n", a)
 	println("--------------------\n")
+
+	one := cy.Parse("1.2")
+	two := cy.Parse("-1.1")
+	result := cy.Add(one, two)
+	fmt.Printf("%s\t%s\n", result.String(), result.Debug())
+	fmt.Printf("Packed: %#064b\n", result)
+	fmt.Printf("Packed: %#016X\n", result)
+	fmt.Printf("Packed: %020d\n", result)
+	println("--------------------")
 }


### PR DESCRIPTION
This pull request includes several changes to the `fixedpoint` package, focusing on adding new quantization functions, updating existing rounding functions, and improving benchmarks. The most important changes include the addition of the `quantize64` and `quantize32` functions, updates to the rounding functions, and new benchmarks for performance testing.

### New Quantization Functions:
* Added `quantize64` and `quantize32` functions to adjust decimal values to the target exponent using specified rounding modes. These functions implement the IEEE 754-2008 quantize operation. (`fixedpoint/fixedpoint.go` [fixedpoint/fixedpoint.goR79-R237](diffhunk://#diff-0b556526657d6e1058f323949260d34127c6307c58a782259530c04139918991R79-R237))

### Updates to Rounding Functions:
* Renamed and updated the `Apply` function to `apply` to reduce a coefficient to the target precision, and changed its parameters to use `Precision` type. (`fixedpoint/rounding.go` [fixedpoint/rounding.goL73-R85](diffhunk://#diff-bd9700e878bbb35e69a85e1b94b0a3f210e5c345c2755f5cdf116e29a9249453L73-R85))
* Updated the `countDigits` function to return `uint8` instead of `uint`. (`fixedpoint/rounding.go` [fixedpoint/rounding.goL143-R152](diffhunk://#diff-bd9700e878bbb35e69a85e1b94b0a3f210e5c345c2755f5cdf116e29a9249453L143-R152))

### Benchmarks:
* Added new benchmarks for `quantize64`, `String`, and `Parse` functions to measure performance. (`fixedpoint/fixedpoint_benchmark_test.go` [fixedpoint/fixedpoint_benchmark_test.goR32-R64](diffhunk://#diff-5dc50c8888390bd8516975bc6995a84fcb744828cdb4b7e1abc06ae2be5906b4R32-R64))

### Constants and Identifiers:
* Renamed constants and identifiers for better readability and consistency, such as `Elimit32` to `eLimit32`, `Emax32` to `eMax32`, and so on. (`fixedpoint/x32.go` [[1]](diffhunk://#diff-c01355499d42cc1a83c6c715431379b9a6465ae7fdf666c9494a6f2f6256e51fL13-R24) `fixedpoint/x64.go` [[2]](diffhunk://#diff-e0682f64bca395574bcb2364ef0d49b3cf8233aeda5a60e6f2856e31be20a222L15-R26)

### Test Adjustments:
* Updated tests to use the new `apply` function and adjusted precision types accordingly. (`fixedpoint/rounding_test.go` [[1]](diffhunk://#diff-4bdfe861d7092bf00d90579e306d9d2f6b856d43c2745e9cf7cc6b1cdc51ac38L43-R43) [[2]](diffhunk://#diff-4bdfe861d7092bf00d90579e306d9d2f6b856d43c2745e9cf7cc6b1cdc51ac38L108-R108)